### PR TITLE
id3.ID3TimeStamp comparator: check type

### DIFF
--- a/mutagen/id3/_specs.py
+++ b/mutagen/id3/_specs.py
@@ -463,7 +463,7 @@ class ID3TimeStamp(object):
         return repr(self.text)
 
     def __eq__(self, other):
-        return self.text == other.text
+        return isinstance(other, ID3TimeStamp) and self.text == other.text
 
     def __lt__(self, other):
         return self.text < other.text


### PR DESCRIPTION
pyyaml's yaml.dump() failed because it apparently compares instances of ID3TimeStamp with None and empty tuples

```
f = mutagen.File(path)
yaml.dump({'file': f})
```